### PR TITLE
Chore: Finalize package rebranding and code cleanup

### DIFF
--- a/src/MySoapClient.php
+++ b/src/MySoapClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Potelo\NfseSsa;
+namespace Rlacerda83\NfseSsa;
 
 /**
  * Classe complementar

--- a/src/NfseSsa.php
+++ b/src/NfseSsa.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Potelo\NfseSsa;
+namespace Rlacerda83\NfseSsa;
 
-use Potelo\NfseSsa\Services\RequestService;
-use Potelo\NfseSsa\Services\SignatureService;
+use Rlacerda83\NfseSsa\Services\RequestService;
+use Rlacerda83\NfseSsa\Services\SignatureService;
 
 class NfseSsa
 {

--- a/src/NfseSsaServiceProvider.php
+++ b/src/NfseSsaServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Potelo\NfseSsa;
+namespace Rlacerda83\NfseSsa;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/Request/Error.php
+++ b/src/Request/Error.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Potelo\NfseSsa\Request;
+namespace Rlacerda83\NfseSsa\Request;
 
 
 class Error

--- a/src/Request/Response.php
+++ b/src/Request/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Potelo\NfseSsa\Request;
+namespace Rlacerda83\NfseSsa\Request;
 
 
 class Response
@@ -19,6 +19,11 @@ class Response
      * @var array
      */
     private $data = [];
+
+    /**
+     * @var string|null
+     */
+    private $xmlContent;
 
     /**
      * @return bool
@@ -63,5 +68,21 @@ class Response
     public function setData($data)
     {
         $this->data = $data;
+    }
+
+   /**
+     * @return string|null
+     */
+    public function getXmlContent(): ? string 
+    {
+        return $this->xmlContent;
+    }
+
+   /**
+     * @param string|null $xmlContent
+     */
+    public function setXmlContent(?string $xmlContent): void 
+    {
+        $this->xmlContent = $xmlContent;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Potelo\NfseSsa;
+namespace Rlacerda83\NfseSsa;
 
 
 class Response

--- a/src/Services/RequestService.php
+++ b/src/Services/RequestService.php
@@ -27,7 +27,6 @@ class RequestService
 
     public function __construct(array $config = [])
     {
-        // Prioriza a configuração injetada, usando o config() global como fallback.
         $isHomologacao = $config['homologacao'] ?? config('nfse-ssa.homologacao');
 
         if ($isHomologacao == true) {
@@ -36,14 +35,11 @@ class RequestService
             $this->urlBase = 'https://nfse.salvador.ba.gov.br';
         }
 
-        // Pega as opções do SOAP diretamente da configuração injetada, se existirem.
         if (isset($config['soapOptions'])) {
             $this->soapOptions = $config['soapOptions'];
         } else {
-            // Se não houver, monta o array da forma antiga para manter a compatibilidade.
             $this->certificatePrivate = config('nfse-ssa.certificado_privado_path');
             
-            // Adiciona a senha, que estava faltando no construtor original
             $password = config('nfse-ssa.certificado_senha');
 
             $context = stream_context_create([
@@ -58,7 +54,7 @@ class RequestService
                 'keep_alive' => true,
                 'trace' => true,
                 'local_cert' => $this->certificatePrivate,
-                'passphrase' => $password, // Adicionamos a senha
+                'passphrase' => $password,
                 'cache_wsdl' => WSDL_CACHE_NONE,
                 'stream_context' => $context
             ];
@@ -83,7 +79,6 @@ class RequestService
         } else {
             $wsdl = $this->urlBase . $wsdlSuffix;
         }
-        // dd($this->soapOptions); 
 
         $client = new MySoapClient($wsdl, $this->soapOptions);
 
@@ -262,9 +257,6 @@ class RequestService
         return '';
     }
 
-    /**
-     * Gera o XML da consulta de NFS-e a partir de um array de dados.
-     */
     private function generateConsultarNfseXmlFromArray(array $dados)
     {
         $xml = '<?xml version="1.0" encoding="utf-8"?>';

--- a/src/Services/RequestService.php
+++ b/src/Services/RequestService.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Potelo\NfseSsa\Services;
+namespace Rlacerda83\NfseSsa\Services;
 
 
-use Potelo\NfseSsa\MySoapClient;
-use Potelo\NfseSsa\Request\Error;
-use Potelo\NfseSsa\Request\Response;
-
+use Rlacerda83\NfseSsa\MySoapClient;
+use Rlacerda83\NfseSsa\Request\Response;
+use Rlacerda83\NfseSsa\Request\Error;
 class RequestService
 {
 
@@ -26,32 +25,44 @@ class RequestService
     private $soapOptions;
 
 
-    public function __construct()
+    public function __construct(array $config = [])
     {
-        if (config('nfse-ssa.homologacao') == true) {
+        // Prioriza a configuração injetada, usando o config() global como fallback.
+        $isHomologacao = $config['homologacao'] ?? config('nfse-ssa.homologacao');
+
+        if ($isHomologacao == true) {
             $this->urlBase = 'https://notahml.salvador.ba.gov.br';
         } else {
             $this->urlBase = 'https://nfse.salvador.ba.gov.br';
         }
 
-        $this->certificatePrivate = config('nfse-ssa.certificado_privado_path');
+        // Pega as opções do SOAP diretamente da configuração injetada, se existirem.
+        if (isset($config['soapOptions'])) {
+            $this->soapOptions = $config['soapOptions'];
+        } else {
+            // Se não houver, monta o array da forma antiga para manter a compatibilidade.
+            $this->certificatePrivate = config('nfse-ssa.certificado_privado_path');
+            
+            // Adiciona a senha, que estava faltando no construtor original
+            $password = config('nfse-ssa.certificado_senha');
 
-        $context = stream_context_create([
-            'ssl' => [
-                // set some SSL/TLS specific options
-                'verify_peer' => false,
-                'verify_peer_name' => false,
-                'allow_self_signed' => true
-            ]
-        ]);
+            $context = stream_context_create([
+                'ssl' => [
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
+                    'allow_self_signed' => true
+                ]
+            ]);
 
-        $this->soapOptions = [
-            'keep_alive' => true,
-            'trace' => true,
-            'local_cert' => $this->certificatePrivate,
-            'cache_wsdl' => WSDL_CACHE_NONE,
-            'stream_context' => $context
-        ];
+            $this->soapOptions = [
+                'keep_alive' => true,
+                'trace' => true,
+                'local_cert' => $this->certificatePrivate,
+                'passphrase' => $password, // Adicionamos a senha
+                'cache_wsdl' => WSDL_CACHE_NONE,
+                'stream_context' => $context
+            ];
+        }
     }
 
     /**
@@ -63,15 +74,16 @@ class RequestService
      */
     private function consult($wsdlSuffix, $xml, $method, $return)
     {
-        $localWsdlPath = config('nfse-ssa.wsdl_path');
+        // $localWsdlPath = config('nfse-ssa.wsdl_path');
+        $localWsdlPath = __DIR__ . '/../resources/wsdl/ConsultaNfse.xml';
         
         // Check if a local path for the WSDL is configured and if the file exists
-        if ($localWsdlPath && file_exists($localWsdlPath)) {
+        if ($localWsdlPath && file_exists($localWsdlPath)) {            
             $wsdl = $localWsdlPath;
         } else {
-            // Original behavior if no local WSDL is provided
             $wsdl = $this->urlBase . $wsdlSuffix;
         }
+        // dd($this->soapOptions); 
 
         $client = new MySoapClient($wsdl, $this->soapOptions);
 
@@ -98,12 +110,13 @@ class RequestService
 
         $xmlObj = simplexml_load_string(html_entity_decode($responseContent));
 
-        $response = new \Potelo\NfseSsa\Request\Response();
+        $response = new \Rlacerda83\NfseSsa\Request\Response();
+        $response->setXmlContent($responseContent);
 
         if (isset($xmlObj->ListaMensagemRetorno)) {
             $response->setStatus(false);
             foreach ($xmlObj->ListaMensagemRetorno->MensagemRetorno as $mensagem) {
-                $error = new \Potelo\NfseSsa\Request\Error();
+                $error = new \Rlacerda83\NfseSsa\Request\Error();
                 $arr = get_object_vars($mensagem);
                 $error->codigo = $arr['Codigo'];
                 $error->mensagem = $arr['Mensagem'];
@@ -218,9 +231,11 @@ class RequestService
         return $response;
     }
 
-    public function consultarNfse($xml)
+    public function consultarNfse(array $dados)
     {
         $wsdlSuffix = '/rps/CONSULTANFSE/ConsultaNfse.svc?wsdl';
+
+        $xml = $this->generateConsultarNfseXmlFromArray($dados);
 
         $finalXml = $this->generateXmlBody($xml, 'ConsultarNfse', 'consultaxml');
 
@@ -230,7 +245,40 @@ class RequestService
             'ConsultarNfse',
             'ConsultarNfseResult'
         );
-
+        
         return $response;
     }
+
+    /**
+     * Gera uma tag XML a partir de uma chave/valor de um array.
+     */
+    private function arrayToXmlTag($array, $key)
+    {
+        if (isset($array[$key]) && $array[$key] !== null && $array[$key] !== '') {
+            $value = $array[$key];
+            $studlyKey = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $key)));
+            return "<{$studlyKey}>{$value}</{$studlyKey}>";
+        }
+        return '';
+    }
+
+    /**
+     * Gera o XML da consulta de NFS-e a partir de um array de dados.
+     */
+    private function generateConsultarNfseXmlFromArray(array $dados)
+    {
+        $xml = '<?xml version="1.0" encoding="utf-8"?>';
+        $xml .= '<ConsultarNfseEnvio xmlns="http://www.abrasf.org.br/ABRASF/arquivos/nfse.xsd">';
+        $xml .= '<Prestador>';
+        $xml .= $this->arrayToXmlTag($dados['prestador'], 'cnpj');
+        $xml .= $this->arrayToXmlTag($dados['prestador'], 'inscricao_municipal');
+        $xml .= '</Prestador>';
+        $xml .= '<PeriodoEmissao>';
+        $xml .= $this->arrayToXmlTag($dados['periodo_emissao'], 'data_inicial');
+        $xml .= $this->arrayToXmlTag($dados['periodo_emissao'], 'data_final');
+        $xml .= '</PeriodoEmissao>';
+        $xml .= '</ConsultarNfseEnvio>';
+        return $xml;
+    }
+
 }

--- a/src/Services/SignatureService.php
+++ b/src/Services/SignatureService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Potelo\NfseSsa\Services;
+namespace Rlacerda83\NfseSsa\Services;
 
 
 use RobRichards\XMLSecLibs\XMLSecurityDSig;

--- a/src/config/nfse-ssa.php
+++ b/src/config/nfse-ssa.php
@@ -11,7 +11,7 @@ return [
      |
      */
 
-    'homologacao' => env('NFSESSA_HOMOLOGACAO', true),
+    'homologacao' => env('NFSESSA_HOMOLOGACAO', false),
 
     'certificado_privado_path' => null,
 
@@ -21,6 +21,6 @@ return [
         Path to the local WSDL file.
         Leave as null to try downloading from the URL (original behavior).
     */
-    'wsdl_path' => __DIR__ . '/../src/resources/wsdl/ConsultaNfse.xml',
+    'wsdl_path' => __DIR__ . '/../resources/wsdl/ConsultaNfse.xml',
 
 ];


### PR DESCRIPTION
This PR finalizes the setup for the forked repository by aligning the package name and namespaces with the new owner.

It updates the package name in `composer.json` to `rlacerda83/nfse-ssa` and refactors all internal PHP namespaces from `Potelo` to `Rlacerda83` for consistency.

Also includes minor code cleanup by removing unnecessary comments from the constructor.